### PR TITLE
[FEATURE] Aliases

### DIFF
--- a/commands/about.ts
+++ b/commands/about.ts
@@ -47,6 +47,7 @@ export const config = {
     name: 'about',
     description: 'Learn about me!',
     enabled: true,
+    aliases: [],
 
     // To restrict the command, change the "false" to the following
     // format:

--- a/commands/branch.ts
+++ b/commands/branch.ts
@@ -69,6 +69,7 @@ export const config = {
     name: 'branch',
     description: 'Changes the current branch [owner only]',
     enabled: true,
+    aliases: [],
 
     // To restrict the command, change the "false" to the following
     // format:

--- a/commands/credits.ts
+++ b/commands/credits.ts
@@ -94,6 +94,7 @@ export const config = {
     name: 'My Cool Command',
     description: 'Does stuff',
     enabled: true,
+    aliases: [],
 
     // To restrict the command, change the "false" to the following
     // format:

--- a/commands/eval.ts
+++ b/commands/eval.ts
@@ -132,6 +132,7 @@ export const config = {
     name: 'eval',
     description: 'Execute code!',
     enabled: true,
+    aliases: ['e'],
 
     // To restrict the command, change the "false" to the following
     // format:

--- a/commands/exec.ts
+++ b/commands/exec.ts
@@ -154,6 +154,7 @@ export const config = {
     name: 'exec',
     description: 'Execute a `bash` script! [owner only]',
     enabled: true,
+    aliases: ['ex'],
 
     // To restrict the command, change the "false" to the following
     // format:

--- a/commands/fursona.ts
+++ b/commands/fursona.ts
@@ -80,6 +80,7 @@ export const config = {
     name: 'fursona',
     description: 'See/edit your fursona details!',
     enabled: true,
+    aliases: ['sona'],
 
     // To restrict the command, change the "false" to the following
     // format:

--- a/commands/help.ts
+++ b/commands/help.ts
@@ -51,6 +51,7 @@ export const config = {
     name: 'help',
     description: 'List all available commands!',
     enabled: true,
+    aliases: ['h'],
 
     // To restrict the command, change the "false" to the following
     // format:

--- a/commands/hug.ts
+++ b/commands/hug.ts
@@ -56,6 +56,7 @@ export const config = {
     name: 'hug',
     description: 'Hug someone!',
     enabled: true,
+    aliases: [],
 
     // To restrict the command, change the "false" to the following
     // format:

--- a/commands/info.ts
+++ b/commands/info.ts
@@ -69,6 +69,7 @@ export const config = {
     name: 'info',
     description: "Get a user's stats!",
     enabled: true,
+    aliases: ['user'],
 
     // To restrict the command, change the "false" to the following
     // format:

--- a/commands/markov.ts
+++ b/commands/markov.ts
@@ -136,6 +136,7 @@ export const config = {
     name: 'markov',
     description: 'Do some magic with the built-in markov chain generator!',
     enabled: true,
+    aliases: [],
 
     // To restrict the command, change the "false" to the following
     // format:

--- a/commands/owos.ts
+++ b/commands/owos.ts
@@ -72,6 +72,7 @@ export const config = {
     name: 'owos',
     description: 'Shows a leaderboard of the messages containing "owo"!',
     enabled: true,
+    aliases: [],
 
     // To restrict the command, change the "false" to the following
     // format:

--- a/commands/restart.ts
+++ b/commands/restart.ts
@@ -48,6 +48,7 @@ export const config = {
     name: 'restart',
     description: 'Restart the bot!',
     enabled: true,
+    aliases: ['r'],
 
     // To restrict the command, change the "false" to the following
     // format:

--- a/commands/source.ts
+++ b/commands/source.ts
@@ -45,6 +45,7 @@ export const config = {
     name: 'source',
     description: 'Gets the source of the last message',
     enabled: true,
+    aliases: ['src'],
 
     // To restrict the command, change the "false" to the following
     // format:

--- a/commands/tildes.ts
+++ b/commands/tildes.ts
@@ -71,6 +71,7 @@ export const config = {
     name: 'tildes',
     description: 'Shows a leaderboard of the messages ending in "~"!',
     enabled: true,
+    aliases: [],
 
     // To restrict the command, change the "false" to the following
     // format:

--- a/commands/update.ts
+++ b/commands/update.ts
@@ -208,6 +208,7 @@ export const config = {
     name: 'update',
     description: 'Update the bot!',
     enabled: true,
+    aliases: ['upd'],
 
     // To restrict the command, change the "false" to the following
     // format:

--- a/commands/uwuify.ts
+++ b/commands/uwuify.ts
@@ -43,6 +43,7 @@ export const config = {
     name: 'uwuify',
     description: 'Converts all of your text to UwU-talk!\nPowered by [Uwuifier](https://github.com/Schotsl/Uwuifier)',
     enabled: true,
+    aliases: ['uwu'],
 
     // To restrict the command, change the "false" to the following
     // format:

--- a/commands/uwus.ts
+++ b/commands/uwus.ts
@@ -72,6 +72,7 @@ export const config = {
     name: 'uwus',
     description: 'Shows a leaderboard of the messages containing "uwu"!',
     enabled: true,
+    aliases: [],
 
     // To restrict the command, change the "false" to the following
     // format:

--- a/index.ts
+++ b/index.ts
@@ -59,6 +59,7 @@ client.fursonas = new enmap({ name: 'fursonas' });
 // in memory dbs
 client.commands = new enmap();
 client.commandsConfig = new enmap();
+client.commandsRefs = new enmap(); // Refs are basically aliases that "link" to the actual command
 client.modules = new enmap();
 
 // Ready event
@@ -129,6 +130,14 @@ client.on('ready', async () => {
                         l('i', `Loading command "${cmdName}"...`);
                         client.commandsConfig.set(cmdName, commandData.config);
                         client.commands.set(cmdName, commandData);
+                        // Load aliases into the refs along with the base command
+                        l('i', `Loading command aliases for ${cmdName}...`);
+                        l('i', 'Loaded base alias!');
+                        client.commandsRefs.set(cmdName, cmdName); // base
+                        (commandData.config.aliases ?? []).forEach((alias: string) => {
+                            l('i', `Loaded alias ${alias}!`);
+                            client.commandsRefs.set(alias, cmdName);
+                        });
                         l('i', `Finished loading command "${cmdName}"!`);
                     } else if (path.endsWith('.map')) {
                         return;

--- a/index.ts
+++ b/index.ts
@@ -227,7 +227,7 @@ client.on('message', (message: discord.Message) => {
     });
     if (msgIsCommand) {
         const args: string[] = message.content.slice(prefixLen).split(/ +/g);
-        const command: string | undefined = args.shift()?.toLowerCase() ?? '';
+        let command: string | undefined = args.shift()?.toLowerCase() ?? '';
         if (!command) {
             // exit
             return;
@@ -240,6 +240,10 @@ client.on('message', (message: discord.Message) => {
                 message.channel?.id ?? 'unknown'
             }) => ${message.id}`
         );
+
+        log('i', 'Resolving alias...');
+        command = client.commandsRefs.get(command);
+        log('i', `Alias resolved to "${command}"!`);
 
         const commandExec: (
             client: discord.Client,

--- a/templatecmd.ts
+++ b/templatecmd.ts
@@ -33,6 +33,7 @@ export const config = {
     name: 'My Cool Command',
     description: 'Does stuff',
     enabled: true,
+    aliases: [], // command aliases to load
 
     // To restrict the command, change the "false" to the following
     // format:


### PR DESCRIPTION
**Does this Pull Request fix an issue? If so, please mention the issue.**
N/A

**Describe your changes.**
Now commands are loaded into `commandsRefs` as `"commandName" => "commandName"` and `"alias" => "commandName"` where the ref is grabbed for the original command.

**Describe alternatives you've considered**
Detailed checks, but this seems simpler.

**Additional context**
Screenshot of `client.commandsRefs`:

![Screenshot](https://drago.is-inside.me/lJJG12je.png)