### PR TITLE
[FEATURE] close databases on process exit

### DIFF
--- a/src/commands/restart.ts
+++ b/src/commands/restart.ts
@@ -20,7 +20,7 @@
 import type { Client, Message } from 'discord.js';
 
 // Main
-export function run(client: Client, message: Message, args: string[], log: (mode: 'i' | 'w' | 'e', message: string) => void): void {
+export async function run(client: Client, message: Message, args: string[], log: (mode: 'i' | 'w' | 'e', message: string) => void): Promise<void> {
     // Safety check
     if (message.author.id !== client.config.ownerID) {
         console.log('w', `User ${message.author.tag} tried to use "restart"!`);
@@ -32,7 +32,12 @@ export function run(client: Client, message: Message, args: string[], log: (mode
     // restart bot
     message.reply('Goodbye!').then(() => {
         log('w', 'Goodbye!');
+        log('w', 'Killing client...');
         client.destroy();
+        log('w', 'Client killed.');
+        log('w', 'Closing databases...');
+        client.closeDatabases();
+        log('w', 'Closed databases.');
         process.exit();
     });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -262,7 +262,12 @@ process.on('exit', (code) => {
 
 // If we get an uncaught exception, close ASAP.
 process.on('uncaughtException', async (error) => {
+    log('e', 'Killing client...')
     client.destroy();
+    log('e', 'Client killed.');
+    log('e', 'Closing databases...');
+    client.closeDatabases();
+    log('e', 'Closed databases.');
     log('e', 'An uncaught exception occured!');
     log('e', `Error thrown was:`);
     error.stack?.split('\n').forEach((item) => {

--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -44,4 +44,15 @@ export default class Client extends BaseClient {
         this.commandsRefs = new enmap(); // Refs are basically aliases that "link" to the actual command
         this.modules = new enmap();
     }
+
+    public async closeDatabases(): Promise<void> {
+        await this.cooldowns.close();
+        await this.tildes.close();
+        await this.owos.close();
+        await this.uwus.close();
+        await this.ustats.close();
+        await this.uconfs.close();
+        await this.markovMessages.close();
+        await this.fursonas.close();
+    }
 }

--- a/src/lib/types/Augments.d.ts
+++ b/src/lib/types/Augments.d.ts
@@ -51,5 +51,8 @@ declare module 'discord.js' {
         commandsConfig: Enmap<string, CommandConfig>; // NOTE: is this redundant?
         commandsRefs: Enmap<string, string>;
         modules: Enmap<string, Module>;
+
+        // Functions
+        public async closeDatabases(): void;
     }
 }


### PR DESCRIPTION
**Does this Pull Request fix an issue? If so, please mention the issue.**
N/A

**Describe your changes.**
In `data/`, the following files show:
```
2.5M    data/enmap.sqlite
32K    data/enmap.sqlite-shm
5.9M    data/enmap.sqlite-wal
```
You can see how the Write-Ahead-Logging DB is huge!

This is because we don't `#close()` the DB when we are done.

This PR should close databases on process exit, combining the files.

**Describe alternatives you've considered**
Letting the files grow but that's bad.

**Additional context**
![Conversation about the files in the data folder](https://drago.is-inside.me/dmcO7nng.png)